### PR TITLE
Handles IO Errors in CRAM files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.4)
 project(cramore)
 
 set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-result -O3 -pthread")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-result -O3")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/bin")
 
 
@@ -523,6 +523,8 @@ if(NOT CRYPTOLIB)
     message(FATAL_ERROR "libcrypto library not found")
 endif()
 
-target_link_libraries(cramore ${HTS_LIBRARIES} ${ZLIB} ${BZIP2} ${LZMA} ${CURLLIB} ${CRYPTOLIB})
+find_package(Threads REQUIRED)
+
+target_link_libraries(cramore ${HTS_LIBRARIES} ${ZLIB} ${BZIP2} ${LZMA} ${CURLLIB} ${CRYPTOLIB} ${CMAKE_THREAD_LIBS_INIT})
 
 install(TARGETS cramore RUNTIME DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,3 +524,5 @@ if(NOT CRYPTOLIB)
 endif()
 
 target_link_libraries(cramore ${HTS_LIBRARIES} ${ZLIB} ${BZIP2} ${LZMA} ${CURLLIB} ${CRYPTOLIB})
+
+install(TARGETS cramore RUNTIME DESTINATION bin)


### PR DESCRIPTION
I normally shy away from calling exit from inside class methods and would prefer to set error flag and check flag after read calls. But to avoid updating all of the routines that use these readers, I decided to just log to stderr and exit when read errors occur. 

I've tested verify-bam and dense-genotype to confirm that the output matches previous versions of these readers. Though I have not done tests that simulate IO errors.