### PR TITLE
Potential fix for var_dict parsing new variant id format.

### DIFF
--- a/var_dict.h
+++ b/var_dict.h
@@ -76,7 +76,7 @@ class var_dict {
     key.pos1 = (uint64_t)atoll(varid);
     s = varid = s+1;
 
-    while( ( *s ) && ( *s != '_' ) ) ++s;
+    while( ( *s ) && ( *s != ':' ) ) ++s;
     if ( *s == '\0' ) return false;
     key.ref.assign(varid, s-varid);
     s = varid = s+1;


### PR DESCRIPTION
@hyunminkang, the format you are using for variant IDs changed recently (https://github.com/hyunminkang/cramore/commit/a48663dab45148fa06c316e79fa749694b79a1f5#diff-b7213b116568e0c583f3ef82f60181e894a261bde80a11d634a246e7c8367493R548) to use colons to delimit all components of the ID. This caused an error when running the `verify-bam` routine because `var_dict` was still expecting the old format. I pushed this fix to a separate branch because I'm not sure whether this format change was intended for all of the cramore sum commands, and I wanted you to confirm that this is the desired behavior.  